### PR TITLE
Resolved issue #12. Implemented new class `Darling\PHPMockingUtilities\classes\mock\values\MockValue`

### DIFF
--- a/src/classes/mock/values/MockValue.php
+++ b/src/classes/mock/values/MockValue.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\classes\mock\values;
+
+use Darling\PHPMockingUtilities\interfaces\mock\values\MockValue as MockValueInterface;
+use \stdClass;
+
+class MockValue implements MockValueInterface
+{
+
+    public function __construct(private mixed $value = null)
+    {
+        if(!isset($this->value)) {
+            $this->value = $this->randomValue();
+        }
+    }
+
+    private function randomValue(): mixed
+    {
+        $letters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+        $values = [
+            rand(0, 100),
+            str_shuffle($letters),
+            true,
+            false,
+            [],
+            function(): void {},
+            new stdClass(),
+        ];
+        return $values[array_rand($values)];
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+
+}
+

--- a/src/interfaces/mock/values/MockValue.php
+++ b/src/interfaces/mock/values/MockValue.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\interfaces\mock\values;
+
+/**
+ * A MockValue can be used to mock a value.
+ *
+ * @example
+ *
+ * ```
+ * var_dump($mockvalue->value());
+ *
+ * // example output:
+ * bool(true)
+ *
+ * ```
+ */
+interface MockValue
+{
+
+    /**
+     * Return the value of this MockValue.
+     *
+     * @return mixed
+     *
+     * @example
+     *
+     * ```
+     * var_dump($mockvalue->value());
+     *
+     * // example output:
+     * int(88)
+     *
+     * ```
+     *
+     */
+    public function value(): mixed;
+
+}
+

--- a/tests/classes/mock/values/MockValueTest.php
+++ b/tests/classes/mock/values/MockValueTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\tests\classes\mock\values;
+
+use Darling\PHPMockingUtilities\classes\mock\values\MockValue;
+use Darling\PHPMockingUtilities\tests\PHPMockingUtilitiesTest;
+use Darling\PHPMockingUtilities\tests\interfaces\mock\values\MockValueTestTrait;
+
+class MockValueTest extends PHPMockingUtilitiesTest
+{
+
+    /**
+     * The MockValueTestTrait defines
+     * common tests for implementations of the
+     * Darling\PHPMockingUtilities\interfaces\mock\values\MockValue
+     * interface.
+     *
+     * @see MockValueTestTrait
+     *
+     */
+    use MockValueTestTrait;
+
+    protected function setUp(): void
+    {
+        $this->setMockValueTestInstance(
+            new MockValue()
+        );
+    }
+
+}
+

--- a/tests/interfaces/mock/values/MockValueTestTrait.php
+++ b/tests/interfaces/mock/values/MockValueTestTrait.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\tests\interfaces\mock\values;
+
+use Darling\PHPMockingUtilities\interfaces\mock\values\MockValue;
+
+/**
+ * The MockValueTestTrait defines common tests for
+ * implementations of the MockValue interface.
+ *
+ * @see MockValue
+ *
+ */
+trait MockValueTestTrait
+{
+
+    /**
+     * @var MockValue $mockValue
+     *                              An instance of a
+     *                              MockValue
+     *                              implementation to test.
+     */
+    protected MockValue $mockValue;
+
+    /**
+     * Return the MockValue implementation instance to test.
+     *
+     * @return MockValue
+     *
+     */
+    protected function mockValueTestInstance(): MockValue
+    {
+        return $this->mockValue;
+    }
+
+    /**
+     * Set the MockValue implementation instance to test.
+     *
+     * @param MockValue $mockValueTestInstance
+     *                              An instance of an
+     *                              implementation of
+     *                              the MockValue
+     *                              interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setMockValueTestInstance(
+        MockValue $mockValueTestInstance
+    ): void
+    {
+        $this->mockValue = $mockValueTestInstance;
+    }
+
+    /**
+     * Set up an instance of a MockValue implementation to test.
+     *
+     * This method must also set the MockValue implementation instance
+     * to be tested via the setMockValueTestInstance() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * protected function setUp(): void
+     * {
+     *     $this->setMockValueTestInstance(
+     *         new \Darling\PHPMockingUtilities\classes\mock\values\MockValue()
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+
+    /**
+     * Test that the value() method always returns the same value.
+     *
+     * @return void
+     *
+     * @covers MockValue::value()
+     */
+    public function testValueReturnsTheSameValueWhenCalledMoreThanOnce(): void
+    {
+        $this->assertEquals(
+            $this->mockValueTestInstance()->value(),
+            $this->mockValueTestInstance()->value(),
+            $this->testFailedMessage(
+                $this->mockValueTestInstance(),
+                'value',
+                'return the same value when called more than once'
+            )
+        );
+    }
+}
+


### PR DESCRIPTION
Implemented the following new class:

```
Darling\PHPMockingUtilities\classes\mock\values\MockValue

```

Which implements the following interface:

```
<?php

namespace Darling\PHPMockingUtilities\interfaces\mock\values;

/**
 * A MockValue can be used to mock a value.
 *
 * @example
 *
 * ```
 * var_dump($mockvalue->value());
 *
 * // example output:
 * bool(true)
 *
 * ```
 */
interface MockValue
{

    /**
     * Return the value of this MockValue.
     *
     * @return mixed
     *
     * @example
     *
     * ```
     * var_dump($mockvalue->value());
     *
     * // example output:
     * int(88)
     *
     * ```
     *
     */
    public function value(): mixed;

}

```