### PR TITLE
Continued to address issue #10.  Working on implementing the following interface:  `Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance`

### DIFF
--- a/src/classes/mock/values/MockClassInstance.php
+++ b/src/classes/mock/values/MockClassInstance.php
@@ -3,29 +3,303 @@
 namespace Darling\PHPMockingUtilities\classes\mock\values;
 
 use Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance as MockClassInstanceInterface;
-use \stdClass;
 use \Darling\PHPReflectionUtilities\classes\utilities\Reflection;
 use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection as ReflectionInterface;
+use \Darling\PHPTextTypes\classes\strings\SafeText;
+use \Darling\PHPTextTypes\classes\strings\Text;
+use \Darling\PHPTextTypes\classes\strings\UnknownClass;
 use \ReflectionClass;
+use \ReflectionException;
+use \RuntimeException;
+use \stdClass;
 
 class MockClassInstance implements MockClassInstanceInterface
 {
 
-    public function __construct(private ReflectionInterface $reflection) {}
+    private const ARRAY = 'array';
+    private const BOOLEAN = 'bool';
+    private const CONSTRUCT = '__construct';
+    private const DOUBLE = 'double';
+    private const INTEGER = 'int';
+    private const NULL = 'NULL';
+    private const STRING = 'string';
 
-    public function mockInstance(array $constructorArguments = []): object
-    {
-        return new stdClass();
-    }
+     /**
+      * Instantiate a new instance of a MockClassInstance.
+      *
+      * @example
+      *
+      * ```
+      * $mocker = new MockClassInstance(
+      *     new Reflection(
+      *         new \ReflectionClass(new \stdClass())
+      *     );
+      *
+      * ```
+      *
+      * @see \Darling\PHPReflectionUtilities\classes\utilities\Reflection
+      * @see https://github.com/sevidmusic/PHPReflectionUtilities/blob/main/src/interfaces/utilities/Reflection.php
+      * @see \ReflectionClass
+      * @see https://www.php.net/manual/en/class.reflectionclass
+      *
+      */
+    public function __construct(private ReflectionInterface $reflection) {}
 
     public function mockMethodArguments(string $method): array
     {
-        return [];
+        return $this->generateMockClassMethodArguments(
+            $this->reflection()->type()->__toString(),
+            $method
+        );
     }
 
     public function reflection(): ReflectionInterface
     {
         return $this->reflection;
     }
+
+     /**
+      * Return an instance of a ReflectionClass that reflects the
+      * specified class or object instance.
+      *
+      * @param class-string|object $class
+      *
+      * @return ReflectionClass<object>
+      *
+      * @example
+      *
+      * ```
+      * var_dump($this->reflectionClass(new stdClass()));
+      *
+      * // example output:
+      * class ReflectionClass#1 (1) {
+      *   public string $name =>
+      *   string(8) "stdClass"
+      * }
+      *
+      * ```
+      * @todo Consider refactoring $class to accept Darling\PHPTextTypes\classes\strings\ClassString once https://github.com/sevidmusic/PHPReflectionUtilities/issues/25 is resolved
+      *
+      */
+     private function reflectionClass(
+         string|object $class
+     ): ReflectionClass
+    {
+        if(
+            class_exists(
+                (
+                    is_object($class)
+                    ? $class::class
+                    : $class
+                )
+            )
+        ) {
+            return new ReflectionClass($class);
+        }
+        return new ReflectionClass(new UnknownClass());
+    }
+
+     /**
+      * Return a mock instance of the same type as the
+      * class or object instance reflected by the
+      * Reflection assigned to the $reflection property.
+      *
+      * If supplied, the specified $constructorArguments will
+      * be passed to the mock instance's constructor.
+      *
+      * @param array<mixed> $constructorArguments
+      *
+      * @return object
+      *
+      * @example
+      *
+      * ```
+      * $mocker = new Mocker(new ObjectReflection(new stdClass()));
+      *
+      * $mockInstance = $mocker->mockInstance();
+      *
+      * var_dump($mockInstance);
+      *
+      * // example output:
+      * class stdClass#38 (0) {
+      * }
+      *
+      * ```
+      *
+      */
+     public function mockInstance(
+         array $constructorArguments = []
+     ): object
+     {
+         return $this->getClassInstance(
+             $this->reflection->type()->__toString(),
+             $constructorArguments
+         );
+     }
+
+     /**
+      * Return a mock instance of the same type as the
+      * specified class or object instance.
+      *
+      * If supplied, the specified $constructorArguments will
+      * be passed to the mock instance's constructor.
+      *
+      * @param class-string|object $class
+      *
+      * @param array<mixed> $constructorArguments
+      *
+      * @return object
+      *
+      * @example
+      *
+      * ```
+      * $mockInstance = $this->getClassInstance(new stdClass());
+      *
+      * var_dump($mockInstance);
+      *
+      * // example output:
+      * class stdClass#38 (0) {
+      * }
+      *
+      * ```
+      *
+      */
+     private function getClassInstance(
+         string|object $class,
+         array $constructorArguments = []
+     ): object
+     {
+        if (method_exists($class, self::CONSTRUCT) === false) {
+            try {
+                return $this->reflectionClass($class)
+                            ->newInstanceArgs([]);
+            } catch (ReflectionException $e) {
+                return $e;
+            }
+        }
+        if (empty($constructorArguments) === true) {
+            try {
+                return $this->reflectionClass($class)
+                            ->newInstanceArgs(
+                                $this->generateMockClassMethodArguments(
+                                    $class,
+                                    self::CONSTRUCT
+                                )
+                );
+            } catch (ReflectionException $e) {
+                return $e;
+            }
+        }
+        return $this->reflectionClass($class)->newInstanceArgs(
+            $constructorArguments
+        );
+    }
+
+     /**
+      * Generate mock method arguments for the specified method of the
+      * provided class or object instance.
+      *
+      * @param class-string|object $class The class or object instance.
+      *
+      * @param string $method The name of the method to generate
+      *                       arguments for.
+      *
+      * @return array<mixed>
+      *
+      * @example
+      *
+      * ```
+      * //
+      * var_dump(
+      *     $mocker->generateMockClassMethodArguments(
+      *         \Darling\PHPTextTypes\classes\strings\Text::class,
+      *         '__construct'
+      *     )
+      * );
+      *
+      * array(1) {
+      *   'string' =>
+      *   string(21) "Mocker-DEFAULT_STRING"
+      * }
+      *
+      * ```
+      *
+      */
+    private function generateMockClassMethodArguments(
+         string|object $class,
+         string $method
+    ): array
+    {
+        $reflection = new Reflection($this->reflectionClass($class));
+        $defaultText = new SafeText(new Text(self::class . '-DEFAULT_STRING'));
+        $defaults = array();
+        if(method_exists($class, $method)) {
+            foreach (
+                $reflection->methodParameterTypes($method)
+                as
+                $name => $types
+            ) {
+                foreach($types as $type) {
+                    if ($type === self::BOOLEAN) {
+                        $defaults[$name] = false;
+                        continue;
+                    }
+                    if ($type === self::INTEGER) {
+                        $defaults[$name] = 1;
+                        continue;
+                    }
+                    if ($type === self::DOUBLE) {
+                        $defaults[$name] = 1.2345;
+                        continue;
+                    }
+                    if ($type === self::STRING) {
+                        $defaults[$name] = $defaultText->__toString();
+                        continue;
+                    }
+                    if ($type === self::ARRAY) {
+                        $defaults[$name] = [];
+                        continue;
+                    }
+                    if ($type === self::NULL) {
+                        $defaults[$name] = null;
+                        continue;
+                    }
+                    /**
+                     * For unknown types check if $type matches an
+                     * existing class, if so, assign an instance of
+                     * that class.
+                     * @var class-string<object> $type
+                     */
+                    $type = '\\' . str_replace(
+                        ['interfaces'],
+                        ['classes'],
+                        $type
+                    );
+                    if(class_exists($type)) {
+                        $defaults[$name] = $this->getClassInstance(
+                            $type
+                        );
+                    }
+                    if(empty($defaults)) {
+                        throw new RuntimeException(
+                            self::class .
+                            ' Error:' .
+                            PHP_EOL .
+                            'Failed to mock argument ' .
+                            $name .
+                            ' of type ' .
+                            $type .
+                            ' for method ' .
+                            self::class .
+                            '->' .
+                            $method
+                        );
+                    }
+                }
+            }
+        }
+        return $defaults;
+    }
+
 }
 

--- a/src/classes/mock/values/MockClassInstance.php
+++ b/src/classes/mock/values/MockClassInstance.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\classes\mock\values;
+
+use Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance as MockClassInstanceInterface;
+use \stdClass;
+use \Darling\PHPReflectionUtilities\classes\utilities\Reflection;
+use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection as ReflectionInterface;
+use \ReflectionClass;
+
+class MockClassInstance implements MockClassInstanceInterface
+{
+
+    public function __construct(private ReflectionInterface $reflection) {}
+
+    public function mockInstance(array $constructorArguments = []): object
+    {
+        return new stdClass();
+    }
+
+    public function mockMethodArguments(string $method): array
+    {
+        return [];
+    }
+
+    public function reflection(): ReflectionInterface
+    {
+        return $this->reflection;
+    }
+}
+

--- a/src/interfaces/mock/values/MockClassInstance.php
+++ b/src/interfaces/mock/values/MockClassInstance.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\interfaces\mock\values;
+
+use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection;
+
+/**
+ * A MockClassInstance can mock an instance of a class or object
+ * instance that is reflected by a Reflection.
+ *
+ * A MockClassInstance can also mock argument values for methods
+ * defined by an instance of a class or object instance that is
+ * reflected by a Reflection.
+ *
+ * @example
+ *
+ * ```
+ * var_dump($mocker->reflection()->type()->__toString());
+ *
+ * // example output:
+ * string(8) "stdClass"
+ *
+ * $mockInstance = $mocker->mockInstance();
+ *
+ * var_dump($mockInstance);
+ *
+ * // example output:
+ * class stdClass#38 (0) {
+ * }
+ *
+ * var_dump($mocker->mockMethodArguments('__construct'));
+ *
+ * // example output:
+ * array(0) {
+ * }
+ *
+ * ```
+ *
+ * @see Darling\PHPReflectionUtilities\interfaces\utilities\Reflection
+ * @see https://github.com/sevidmusic/PHPReflectionUtilities/blob/main/src/interfaces/utilities/Reflection.php
+ *
+ */
+interface MockClassInstance
+{
+
+     /**
+      * Return a mock instance of the same type as the
+      * class or object instance reflected by the
+      * Reflection assigned to this MockClassInstance.
+      *
+      * If supplied, the specified $constructorArguments will
+      * be passed to the mock instance's constructor.
+      *
+      * @param array<mixed> $constructorArguments
+      *
+      * @return object
+      *
+      * @example
+      *
+      * ```
+      * var_dump($mocker->reflection()->type()->__toString());
+      *
+      * // example output:
+      * string(8) "stdClass"
+      *
+      * $mockInstance = $mocker->mockInstance();
+      *
+      * var_dump($mockInstance);
+      *
+      * // example output:
+      * class stdClass#38 (0) {
+      * }
+      *
+      * ```
+      *
+      */
+    public function mockInstance(array $constructorArguments = []): object;
+
+     /**
+      * Generate mock method arguments for the specified method of the
+      * class or object instance reflected by this MockClassInstance's
+      * Reflection.
+      *
+      * @param string $method The name of the method to generate
+      *                       arguments for.
+      *
+      * @return array<mixed>
+      *
+      * @example
+      *
+      * ```
+      * var_dump($mocker->reflection()->type()->__toString());
+      *
+      * // example output:
+      * string(8) "stdClass"
+      *
+      * var_dump($mocker->mockMethodArguments('__construct'));
+      *
+      * // example output:
+      * array(0) {
+      * }
+      *
+      * ```
+      *
+      */
+    public function mockMethodArguments(string $method): array;
+
+
+    /**
+     * Return the Reflection that reflects the class or object
+     * instance this MockClassInstance mocks.
+     *
+     * @return Reflection
+     *
+     * @example
+     *
+     * ```
+     * var_dump($mocker->reflection());
+     *
+     * // example output:
+     * class Darling\PHPReflectionUtilities\classes\utilities\Reflection#25 (1) {
+     *   private ReflectionClass $reflectionClass =>
+     *   class ReflectionClass#38 (1) {
+     *     public string $name =>
+     *     string(8) "stdClass"
+     *   }
+     * }
+     *
+     * ```
+     */
+    public function reflection(): Reflection;
+
+}
+

--- a/tests/classes/mock/values/MockClassInstanceTest.php
+++ b/tests/classes/mock/values/MockClassInstanceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\tests\classes\mock\values;
+
+use Darling\PHPMockingUtilities\classes\mock\values\MockClassInstance;
+use Darling\PHPMockingUtilities\tests\PHPMockingUtilitiesTest;
+use Darling\PHPMockingUtilities\tests\interfaces\mock\values\MockClassInstanceTestTrait;
+use \Darling\PHPReflectionUtilities\classes\utilities\Reflection;
+use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection as ReflectionInterface;
+use \ReflectionClass;
+
+class MockClassInstanceTest extends PHPMockingUtilitiesTest
+{
+
+    /**
+     * The MockClassInstanceTestTrait defines
+     * common tests for implementations of the
+     * Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance
+     * interface.
+     *
+     * @see MockClassInstanceTestTrait
+     *
+     */
+    use MockClassInstanceTestTrait;
+
+    public function setUp(): void
+    {
+        $expectedReflection = new Reflection(
+            new ReflectionClass(new \stdClass()) # todo: use random class instance
+        );
+        $this->setExpectedReflection($expectedReflection);
+        $this->setMockClassInstanceTestInstance(
+            new MockClassInstance($expectedReflection)
+        );
+    }
+}
+

--- a/tests/classes/mock/values/MockClassInstanceTest.php
+++ b/tests/classes/mock/values/MockClassInstanceTest.php
@@ -25,13 +25,97 @@ class MockClassInstanceTest extends PHPMockingUtilitiesTest
 
     public function setUp(): void
     {
+        $randomClassStringOrObjectInstance = $this->randomClassStringOrObjectInstance();
         $expectedReflection = new Reflection(
-            new ReflectionClass(new \stdClass()) # todo: use random class instance
+            new ReflectionClass(
+                $randomClassStringOrObjectInstance
+            )
         );
         $this->setExpectedReflection($expectedReflection);
         $this->setMockClassInstanceTestInstance(
             new MockClassInstance($expectedReflection)
         );
     }
+
+    /**
+     * Return a random fully qualified class name, or object instance.
+     *
+     * @return class-string|object
+     *
+     * @example
+     *
+     * ```
+     * var_dump($this->randomClassStringOrObjectInstance);
+     *
+     * // example output:
+     * string(8) "stdClass"
+     *
+     * ```
+     *
+     */
+    public function randomClassStringOrObjectInstance(): string|object
+    {
+        /** @var array<int, class-string|object> $classes */
+        $classes = [
+            new \stdClass(),
+            ClassThatDoesDefineMethods::class,
+            ClassThatDoesDefineMethods::class,
+            new ClassThatDoesNotDefineMethods(),
+            new ClassThatDoesDefineMethods(),
+            parent::randomClassStringOrObjectInstance(),
+        ];
+        return $classes[array_rand($classes)];
+    }
 }
 
+/**
+ * The following classes are defined here for use by
+ * the MockClassInstanceTest
+ *
+ * @todo Move test classes into their own files
+ *
+ */
+
+class ClassThatDoesNotDefineMethods
+{
+
+}
+
+class ClassThatDoesDefineMethods
+{
+
+    public function __constuct(int $int, bool $bool): void {}
+
+    public function methodWithoutArguments(): void {}
+
+    /**
+     * A method that expects arguments.
+     *
+     * @param array<mixed> $array
+     * @param string|array<mixed> $moreThanOneTypeAccepted
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     *
+     * ```
+     *
+     */
+    public function methodWithArguments(
+        string $string,
+        int $int,
+        bool $bool,
+        float $float,
+        array $array,
+        object $object,
+        mixed $mixed,
+        string|array $moreThanOneTypeAccepted,
+        ClassThatDoesNotDefineMethods $classWithoutMethods,
+        ClassThatDoesDefineMethods $classWithMethods,
+        null|bool|int $nullableParameter,
+    ): void
+    {
+    }
+}

--- a/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
+++ b/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
@@ -16,24 +16,34 @@ use \ReflectionClass;
 trait MockClassInstanceTestTrait
 {
 
+    /**
+     * @var Reflection $expectedReflection The Reflection instance
+     *                                     that is expected to be
+     *                                     assigned to the
+     *                                     MockClassInstance being
+     *                                     tested.
+     */
     private Reflection $expectedReflection;
 
     /**
-     * @var MockClassInstance $mockClassInstance
-     *                              An instance of a
-     *                              MockClassInstance
-     *                              implementation to test.
+     * @var MockClassInstance $mockClassInstance An instance of a
+     *                                           MockClassInstance
+     *                                           implementation to
+     *                                           test.
      */
     protected MockClassInstance $mockClassInstance;
 
     /**
-     * Set up an instance of a MockClassInstance implementation to test.
+     * Set up an instance of a MockClassInstance implementation to
+     * test.
      *
-     * This method must set the MockClassInstance implementation instance
-     * to be tested via the setMockClassInstanceTestInstance() method.
+     * This method must set the MockClassInstance
+     * implementation instance to be tested via the
+     * setMockClassInstanceTestInstance() method.
      *
-     * This method must also set the expected Reflection instance
-     * to via the setExpectedReflection() method.
+     * This method must also set the Reflection instance that is
+     * expected to be assigned to the MockClassInstance being tested
+     * via the setExpectedReflection() method.
      *
      * This method may also be used to perform any additional setup
      * required by the implementation being tested.
@@ -46,7 +56,7 @@ trait MockClassInstanceTestTrait
      * protected function setUp(): void
      * {
      *     $expectedReflection = new Reflection(
-     *         new ReflectionClass(new \stdClass()) # todo: use random class instance
+     *         new ReflectionClass(new \stdClass())
      *     );
      *     $this->setExpectedReflection($expectedReflection);
      *     $this->setMockClassInstanceTestInstance(
@@ -89,18 +99,50 @@ trait MockClassInstanceTestTrait
         $this->mockClassInstance = $mockClassInstanceTestInstance;
     }
 
+    /**
+     * Set the Reflection instance that is expected to be assigned
+     * to the MockClassInstance being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * $expectedReflection = new Reflection(
+     *     new ReflectionClass(new \stdClass())
+     * );
+     * $this->setExpectedReflection($expectedReflection);
+     *
+     * ```
+     *
+     */
     protected function setExpectedReflection(Reflection $reflection): void
     {
         $this->expectedReflection = $reflection;
     }
 
+    /**
+     * Return the Reflection instance that is expected to be
+     * assigned to the MockClassInstance being tested.
+     *
+     * @return Reflection
+     *
+     * @example
+     *
+     * ```
+     * $this->expectedReflection();
+     *
+     * ```
+     *
+     */
     protected function expectedReflection(): Reflection
     {
         return $this->expectedReflection;
     }
 
     /**
-     * Test that the reflection method returns the expected Reflection.
+     * Test that the reflection method returns the expected
+     * Reflection.
      *
      * @covers MockClassInstance->reflection()
      *
@@ -118,5 +160,124 @@ trait MockClassInstanceTestTrait
         );
     }
 
+    /**
+     * Test that the mockInstance() method returns an instance of
+     * a class of the same type as the class or object instance
+     * reflected by the MockClassInstance's Reflection.
+     *
+     * @covers MockClassInstance->mockInstance()
+     *
+     */
+    public function testMockInstanceReturnsAnInstanceOfTheSameTypeAsTheClassOrObjectInstanceReflectedByTheReflectionAssignedToTheMockClassInstance(): void
+    {
+        $this->assertEquals(
+            $this->mockClassInstanceTestInstance()->reflection()->type()->__toString(),
+            $this->mockClassInstanceTestInstance()->mockInstance()::class,
+            $this->testFailedMessage(
+                $this->mockClassInstanceTestInstance(),
+                'mockClassInstance',
+                'return an instance of the same type as the ' .
+                'class or object instance reflected by the Reflection'
+            )
+        );
+    }
+
+
+    /**
+     * Test that the mockMethodArguments() method returns an array
+     * of mock arguments for the specified method of the class
+     * or object instance reflected by the Reflection assigned
+     * to the MockClassInstance.
+     *
+     * @covers MockClassInstance->mockInstance()
+     *
+     */
+    public function testMockMethodArgumentsReturnsAnArrayOfMockArgumentsOfTheCorrectTypeForTheSpecifiedMethodOfTheClassOrObjectInstanceReflectedByTheReflectionAssignedToTheMockClassInstance(): void
+    {
+        $methodNames = $this->mockClassInstanceTestInstance()
+                            ->reflection()
+                            ->methodNames();
+        if(empty($methodNames)) {
+            $this->assertEmpty(
+                $this->mockClassInstanceTestInstance()->mockMethodArguments(''),
+                $this->testFailedMessage(
+                    $this->mockClassInstanceTestInstance(),
+                    'mockMethodArguments',
+                    'return an empty array if the class does not ' .
+                    'define any methods'
+                )
+            );
+        }
+        if(!empty($methodNames)) {
+            $methodName = $methodNames[array_rand($methodNames)];
+            $expectedArgumentTypes =
+                $this->mockClassInstanceTestInstance()
+                     ->reflection()
+                     ->methodParameterTypes($methodName);
+            if(empty($expectedArgumentTypes)) {
+                $this->assertEmpty(
+                    $this->mockClassInstanceTestInstance()->mockMethodArguments($methodName),
+                    $this->testFailedMessage(
+                        $this->mockClassInstanceTestInstance(),
+                        'mockMethodArguments',
+                        'return an empty array if the specified ' .
+                        'method does not expect any arguments'
+                    )
+                );
+            }
+            $mockArguments = $this->mockClassInstanceTestInstance()->mockMethodArguments($methodName);
+            if(
+                !empty($expectedArgumentTypes)
+                &&
+                empty($mockArguments)
+            ) {
+                $this->assertNotEmpty(
+                    $mockArguments,
+                    $this->testFailedMessage(
+                        $this->mockClassInstanceTestInstance(),
+                        'mockMethodArguments',
+                        'return an non-empty array if the ' .
+                        'specified method expects arguments'
+                    )
+                );
+            }
+            if(!empty($expectedArgumentTypes)) {
+                foreach(
+                   $mockArguments
+                     as
+                     $name => $mockArgument
+                ) {
+                    $type = (
+                        is_object($mockArgument)
+                        ? $mockArgument::class
+                        : str_replace(
+                            [
+                                'integer',
+                                'boolean',
+                            ],
+                            [
+                                'int',
+                                'bool',
+                            ],
+                            gettype($mockArgument))
+                    );
+                    $this->assertTrue(
+                        in_array($type, $expectedArgumentTypes[$name], true),
+                        $this->testFailedMessage(
+                            $this->mockClassInstanceTestInstance(),
+                            'mockMethodArguments',
+                            'return an array of mock arguments of ' .
+                            'the correct type for the specified ' .
+                            'method of the class or object ' .
+                            'instance reflected by the ' .
+                            'Reflection assigned to the ' .
+                            'MockClassInstance'
+                        )
+                    );
+                }
+            }
+        }
+
+    }
 }
 

--- a/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
+++ b/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Darling\PHPMockingUtilities\tests\interfaces\mock\values;
+
+use Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance;
+use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection;
+use \ReflectionClass;
+
+/**
+ * The MockClassInstanceTestTrait defines common tests for
+ * implementations of the MockClassInstance interface.
+ *
+ * @see MockClassInstance
+ *
+ */
+trait MockClassInstanceTestTrait
+{
+
+    private Reflection $expectedReflection;
+
+    /**
+     * @var MockClassInstance $mockClassInstance
+     *                              An instance of a
+     *                              MockClassInstance
+     *                              implementation to test.
+     */
+    protected MockClassInstance $mockClassInstance;
+
+    /**
+     * Set up an instance of a MockClassInstance implementation to test.
+     *
+     * This method must set the MockClassInstance implementation instance
+     * to be tested via the setMockClassInstanceTestInstance() method.
+     *
+     * This method must also set the expected Reflection instance
+     * to via the setExpectedReflection() method.
+     *
+     * This method may also be used to perform any additional setup
+     * required by the implementation being tested.
+     *
+     * @return void
+     *
+     * @example
+     *
+     * ```
+     * protected function setUp(): void
+     * {
+     *     $expectedReflection = new Reflection(
+     *         new ReflectionClass(new \stdClass()) # todo: use random class instance
+     *     );
+     *     $this->setExpectedReflection($expectedReflection);
+     *     $this->setMockClassInstanceTestInstance(
+     *         new \Darling\PHPMockingUtilities\classes\mock\values\MockClassInstance()
+     *     );
+     * }
+     *
+     * ```
+     *
+     */
+    abstract protected function setUp(): void;
+
+    /**
+     * Return the MockClassInstance implementation instance to test.
+     *
+     * @return MockClassInstance
+     *
+     */
+    protected function mockClassInstanceTestInstance(): MockClassInstance
+    {
+        return $this->mockClassInstance;
+    }
+
+    /**
+     * Set the MockClassInstance implementation instance to test.
+     *
+     * @param MockClassInstance $mockClassInstanceTestInstance
+     *                              An instance of an
+     *                              implementation of
+     *                              the MockClassInstance
+     *                              interface to test.
+     *
+     * @return void
+     *
+     */
+    protected function setMockClassInstanceTestInstance(
+        MockClassInstance $mockClassInstanceTestInstance
+    ): void
+    {
+        $this->mockClassInstance = $mockClassInstanceTestInstance;
+    }
+
+    protected function setExpectedReflection(Reflection $reflection): void
+    {
+        $this->expectedReflection = $reflection;
+    }
+
+    protected function expectedReflection(): Reflection
+    {
+        return $this->expectedReflection;
+    }
+
+    /**
+     * Test that the reflection method returns the expected Reflection.
+     *
+     * @covers MockClassInstance->reflection()
+     *
+     */
+    public function testReflectionReturnsTheExpectedReflection(): void
+    {
+        $this->assertEquals(
+            $this->expectedReflection(),
+            $this->mockClassInstanceTestInstance()->reflection(),
+            $this->testFailedMessage(
+                $this->mockClassInstanceTestInstance(),
+                'value',
+                'return the expected Reflection'
+            )
+        );
+    }
+
+}
+


### PR DESCRIPTION
commit 3f199e63b210c0c7a71702a74978942d153b42d0 (HEAD -> PHPMockingUtilities1680713356, origin/PHPMockingUtilities1680713356)
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Wed Apr 5 19:29:51 2023 -0400

    Continued to address issue #10.

    Working on implementing the following interface:

    ```
    Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance

    ```

    Implemented the following tests:

    ```
    testMockInstanceReturnsAnInstanceOfTheSameTypeAsTheClassOrObjectInstanceReflectedByTheReflectionAssignedToTheMockClassInstance()
    testMockMethodArgumentsReturnsAnArrayOfMockArgumentsOfTheCorrectTypeForTheSpecifiedMethodOfTheClassOrObjectInstanceReflectedByTheReflectionAssignedToTheMockClassInstance()
    testReflectionReturnsTheExpectedReflection()

    ```