### PR TITLE
Working on addressing issue #10.

### DIFF
--- a/src/classes/mock/values/MockClassInstance.php
+++ b/src/classes/mock/values/MockClassInstance.php
@@ -14,6 +14,7 @@ use \Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance as Moc
 use \Darling\PHPReflectionUtilities\classes\utilities\Reflection;
 use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection as ReflectionInterface;
 use \Darling\PHPTextTypes\classes\strings\UnknownClass;
+use \Darling\PHPTextTypes\classes\strings\ClassString;
 use \ReflectionClass;
 use \ReflectionException;
 use \RuntimeException;
@@ -21,6 +22,17 @@ use \stdClass;
 
 class MockClassInstance implements MockClassInstanceInterface
 {
+
+    private const ARRAY = 'array';
+    private const BOOLEAN = 'bool';
+    private const CONSTRUCT = '__construct';
+    private const DOUBLE = 'double';
+    private const FLOAT = 'float';
+    private const INTEGER = 'int';
+    private const NULL = 'NULL';
+    private const STRING = 'string';
+    private const MIXED = 'mixed';
+    private const OBJECT = 'object';
 
      /**
       * Instantiate a new instance of a MockClassInstance.
@@ -43,23 +55,382 @@ class MockClassInstance implements MockClassInstanceInterface
       */
     public function __construct(private ReflectionInterface $reflection) {}
 
+    public function mockMethodArguments(string $method): array
+    {
+        return $this->generateMockClassMethodArguments(
+            $this->reflection()->type()->__toString(),
+            $method
+        );
+    }
+
     public function reflection(): ReflectionInterface
     {
         return $this->reflection;
     }
 
-    public function mockMethodArguments(string $method): array
-    {
-        return [];
-    }
+     /**
+      * Return an instance of a ReflectionClass that reflects the
+      * specified class or object instance.
+      *
+      * @param class-string|object $class
+      *
+      * @return ReflectionClass<object>
+      *
+      * @example
+      *
+      * ```
+      * var_dump($this->reflectionClass(new stdClass()));
+      *
+      * // example output:
+      * class ReflectionClass#1 (1) {
+      *   public string $name =>
+      *   string(8) "stdClass"
+      * }
+      *
+      * ```
+      *
+      */
+     private function reflectionClass(
+         string|object $class
+     ): ReflectionClass
+     {
+         if(
+             class_exists(
+                 (
+                     is_object($class)
+                     ? $class::class
+                     : $class
+                 )
+             )
+         ) {
+             return new ReflectionClass($class);
+         }
+         return new ReflectionClass(new UnknownClass());
+     }
 
-
+     /**
+      * Return a mock instance of the same type as the
+      * class or object instance reflected by the
+      * Reflection assigned to the $reflection property.
+      *
+      * If supplied, the specified $constructorArguments will
+      * be passed to the mock instance's constructor.
+      *
+      * @param array<mixed> $constructorArguments
+      *
+      * @return object
+      *
+      * @example
+      *
+      * ```
+      * $mocker = new Mocker(new ObjectReflection(new stdClass()));
+      *
+      * $mockInstance = $mocker->mockInstance();
+      *
+      * var_dump($mockInstance);
+      *
+      * // example output:
+      * class stdClass#38 (0) {
+      * }
+      *
+      * ```
+      *
+      */
      public function mockInstance(
          array $constructorArguments = []
      ): object
      {
-         return $this;
+         return $this->getClassInstance(
+             $this->reflection->type()->__toString(),
+             $constructorArguments
+         );
      }
+
+     /**
+      * Return a mock instance of the same type as the
+      * specified class or object instance.
+      *
+      * If supplied, the specified $constructorArguments will
+      * be passed to the mock instance's constructor.
+      *
+      * @param class-string|object $class
+      *
+      * @param array<mixed> $constructorArguments
+      *
+      * @return object
+      *
+      * @example
+      *
+      * ```
+      * $mockInstance = $this->getClassInstance(new stdClass());
+      *
+      * var_dump($mockInstance);
+      *
+      * // example output:
+      * class stdClass#38 (0) {
+      * }
+      *
+      * ```
+      *
+      */
+     private function getClassInstance(
+         string|object $class,
+         array $constructorArguments = []
+     ): object
+     {
+        if (method_exists($class, self::CONSTRUCT) === false) {
+            return $this->reflectionClass($class)
+                        ->newInstanceArgs([]);
+        }
+        return match(empty($constructorArguments)) {
+            true => $this->reflectionClass($class)
+                        ->newInstanceArgs(
+                            $this->generateMockClassMethodArguments(
+                                $class,
+                                self::CONSTRUCT
+                            )
+                        ),
+            default => $this->reflectionClass($class)
+                            ->newInstanceArgs($constructorArguments),
+        };
+    }
+
+     /**
+      * Generate mock method arguments for the specified method of the
+      * provided class or object instance.
+      *
+      * @param class-string|object $class The class or object instance.
+      *
+      * @param string $method The name of the method to generate
+      *                       arguments for.
+      *
+      * @return array<mixed>
+      *
+      * @example
+      *
+      * ```
+      * //
+      * var_dump(
+      *     $mocker->generateMockClassMethodArguments(
+      *         \Darling\PHPTextTypes\classes\strings\Text::class,
+      *         '__construct'
+      *     )
+      * );
+      *
+      * array(1) {
+      *   'string' =>
+      *   string(21) "Mocker-DEFAULT_STRING"
+      * }
+      *
+      * ```
+      *
+      */
+    private function generateMockClassMethodArguments(
+         string|object $class,
+         string $method
+    ): array
+    {
+        $classString = new ClassString($class);
+        $reflection = new Reflection($classString);
+        $defaults = array();
+        if(method_exists($class, $method)) {
+            foreach (
+                $reflection->methodParameterTypes($method)
+                as
+                $name => $types
+            ) {
+                foreach($types as $type) {
+                    if($type === \Closure::class) {
+                        $defaults[$name] = $this->mockClosure();
+                        continue;
+                    }
+                    if($type === \Stringable::class) {
+                        $defaults[$name] = new MockString();
+                        continue;
+                    }
+                    if ($type === self::BOOLEAN) {
+                        $defaults[$name] = $this->mockBool();
+                        continue;
+                    }
+                    if ($type === self::INTEGER) {
+                        $defaults[$name] = $this->mockInt();
+                        continue;
+                    }
+                    if($type === self::FLOAT) {
+                        $defaults[$name] = $this->mockFloat();
+                        continue;
+                    }
+                    if ($type === self::DOUBLE) {
+                        $defaults[$name] = $this->mockFloat();
+                        continue;
+                    }
+                    if ($type === self::STRING) {
+                        $defaults[$name] = $this->mockString();
+                        continue;
+                    }
+                    if ($type === self::ARRAY) {
+                        $defaults[$name] = $this->mockArray();
+                        continue;
+                    }
+                    if ($type === self::MIXED) {
+                        $defaults[$name] = $this->mockMixedValue();
+                        continue;
+                    }
+                    if ($type === self::NULL) {
+                        $defaults[$name] = null;
+                        continue;
+                    }
+                    if ($type === self::OBJECT) {
+                        $defaults[$name] = new stdClass();
+                        continue;
+                    }
+                    $this->attemptToAddAMockInstanceOfTheSpecifiedTypeToArrayUnderTheSpecifiedIndex(
+                        $type,
+                        $name,
+                        $defaults
+                    );
+                    if(empty($defaults)) {
+                        throw new RuntimeException(
+                            PHP_EOL .
+                            PHP_EOL .
+                            self::class .
+                            ' Error:' .
+                            PHP_EOL .
+                            PHP_EOL .
+                            'Failed to mock argument: $' .
+                            $name .
+                            PHP_EOL .
+                            PHP_EOL .
+                            'Expected argument type: ' .
+                            $type .
+                            PHP_EOL .
+                            PHP_EOL .
+                            'Method: ' .
+                            $method .
+                            '()' .
+                            PHP_EOL .
+                            PHP_EOL
+                        );
+                    }
+                }
+            }
+        }
+        return $defaults;
+    }
+
+    /**
+     * Attempt to add a mock instance of the specified $class
+     * to the specified array of $values under the specified
+     * $index.
+     *
+     * If an instance of the specified class can not be mocked,
+     * than the array of $values will not be modified.
+     *
+     * @param string $class The expected type.
+     *
+     * @param string $index The index to assign the instance to
+     *                      in the array of $values.
+     *
+     * @param array<mixed> $values The array of values to add the
+     *                             instance to.
+     */
+    private function attemptToAddAMockInstanceOfTheSpecifiedTypeToArrayUnderTheSpecifiedIndex(
+        string $class,
+        string $index,
+        &$values
+    ): void
+    {
+        /**
+         * Note:
+         *
+         * It is not normally possible to mock an interface or
+         * abstract class since they can not be instantiated.
+         *
+         * However, Darling libraries use a naming convention for
+         * their namespaces that allows this to be overcome.
+         *
+         * By modifying $class so the words 'interfaces' and
+         * 'abstractions' are replaced by the word 'classes'
+         * the correct class can be mocked when a type accepts
+         * an instance of a Darling interface or abstract class.
+         *
+         * THIS ONLY APPLIES TO CLASSES DEFINED BY DARLING LIBRARIES.
+         *
+         * Attempts to mock any other interface or abstract class
+         * will most likely fail unless they happen to use a
+         * namespace that follows one of the following naming
+         * patterns:
+         *
+         * ```
+         * namespace Darling\...\interfaces\...\InterfaceName
+         * namespace Darling\...\abstractions\...\AbstractClassName
+         *
+         * ```
+         *
+         * @var class-string<object> $class
+         */
+        if(substr($class, 0, 7) === 'Darling') {
+            $class = '\\' . str_replace(
+                ['interfaces', 'abstractions'],
+                ['classes'],
+                $class
+            );
+        }
+        /**
+         * If $class matches an existing class assign an instance of
+         * that class to the $values array under the specified $index.
+         */
+        if(class_exists($class)) {
+            $values[$index] = $this->getClassInstance(
+                $class
+            );
+        }
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function mockArray(): array
+    {
+        $mockArray = new MockArray();
+        return $mockArray->value();
+    }
+
+    private function mockString(): string
+    {
+        $mockString = new MockString();
+        return $mockString->value();
+    }
+
+    private function mockBool(): bool
+    {
+        $mockBool = new MockBool();
+        return $mockBool->value();
+    }
+
+    private function mockClosure(): Closure
+    {
+        $mockClosure = new MockClosure();
+        return $mockClosure->value();
+    }
+
+    private function mockFloat(): float
+    {
+        $mockFloat = new MockFloat();
+        return $mockFloat->value();
+    }
+
+    private function mockInt(): int
+    {
+        $mockInt = new MockInt();
+        return $mockInt->value();
+    }
+
+    private function mockMixedValue(): mixed
+    {
+        $mockMixedValue = new MockMixedValue();
+        return $mockMixedValue->value();
+    }
 
 }
 

--- a/tests/classes/mock/values/MockClassInstanceTest.php
+++ b/tests/classes/mock/values/MockClassInstanceTest.php
@@ -85,7 +85,8 @@ class MockClassInstanceTest extends PHPMockingUtilitiesTest
             new Name(new Text($this->randomChars())),
             new Text($this->randomChars()),
             new stdClass(),
-            stdClass::class
+            stdClass::class,
+            parent::randomClassStringOrObjectInstance(),
         ];
         return (empty($classes) ? new stdClass() : $classes[array_rand($classes)]);
     }

--- a/tests/classes/mock/values/MockClassInstanceTest.php
+++ b/tests/classes/mock/values/MockClassInstanceTest.php
@@ -11,10 +11,10 @@ use \Darling\PHPMockingUtilities\tests\mock\classes\ImplementationOfInterfaceFor
 use \Darling\PHPMockingUtilities\tests\mock\interfaces\InterfaceForClassThatDefinesMethods;
 use \Darling\PHPReflectionUtilities\classes\utilities\Reflection;
 use \Darling\PHPReflectionUtilities\interfaces\utilities\Reflection as ReflectionInterface;
+use \Darling\PHPTextTypes\classes\strings\ClassString;
 use \Darling\PHPTextTypes\classes\strings\Name;
 use \Darling\PHPTextTypes\classes\strings\Text;
 use \Darling\PHPTextTypes\classes\strings\UnknownClass;
-use \Darling\PHPTextTypes\classes\strings\ClassString;
 use \Darling\PHPTextTypes\interfaces\strings\Name as NameInterface;
 use \Darling\PHPTextTypes\interfaces\strings\Text as TextInterface;
 use \ReflectionClass;
@@ -35,7 +35,7 @@ class MockClassInstanceTest extends PHPMockingUtilitiesTest
      */
     use MockClassInstanceTestTrait;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $randomClassStringOrObjectInstance = $this->randomClassStringOrObjectInstance();
         $classString =

--- a/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
+++ b/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
@@ -156,7 +156,7 @@ trait MockClassInstanceTestTrait
      * @covers MockClassInstance->reflection()
      *
      */
-    public function testReflectionReturnsTheExpectedReflection(): void
+    public function test_reflection_returns_the_expected_reflection(): void
     {
         $this->assertEquals(
             $this->expectedReflection(),
@@ -177,7 +177,7 @@ trait MockClassInstanceTestTrait
      * @covers MockClassInstance->mockInstance()
      *
      */
-    public function testMockInstanceReturnsAnInstanceOfTheSameTypeAsTheClassOrObjectInstanceReflectedByTheExpectedReflection(): void
+    public function test_mock_instance_returns_an_instance_of_the_same_type_as_the_class_or_object_instance_reflected_by_the_expected_reflection(): void
     {
         $this->assertEquals(
             $this->expectedReflection()->type()->__toString(),
@@ -201,7 +201,7 @@ trait MockClassInstanceTestTrait
      * @covers MockClassInstance->mockInstance()
      *
      */
-    public function testMockInstanceReturnsAnInstanceOfTheSameTypeAsTheClassOrObjectInstanceReflectedByTheReflectionReturnedByTheMockClassInstancesReflectionMethod(): void
+    public function test_mock_instance_returns_an_instance_of_the_same_type_as_the_class_or_object_instance_reflected_by_the_reflection_returned_by_the_mock_class_instances_reflection_method(): void
     {
         $this->assertEquals(
             $this->mockClassInstanceTestInstance()->reflection()->type()->__toString(),

--- a/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
+++ b/tests/interfaces/mock/values/MockClassInstanceTestTrait.php
@@ -168,5 +168,26 @@ trait MockClassInstanceTestTrait
         );
     }
 
+    /**
+     * Test that the mockInstance() method returns an instance of
+     * a class of the same type as the class or object instance
+     * reflected by the MockClassInstance's Reflection.
+     *
+     * @covers MockClassInstance->mockInstance()
+     *
+     */
+    public function testMockInstanceReturnsAnInstanceOfTheSameTypeAsTheClassOrObjectInstanceReflectedByTheReflectionAssignedToTheMockClassInstance(): void
+    {
+        $this->assertEquals(
+            $this->mockClassInstanceTestInstance()->reflection()->type()->__toString(),
+            $this->mockClassInstanceTestInstance()->mockInstance()::class,
+            $this->testFailedMessage(
+                $this->mockClassInstanceTestInstance(),
+                'mockClassInstance',
+                'return an instance of the same type as the ' .
+                'class or object instance reflected by the Reflection'
+            )
+        );
+    }
 }
 


### PR DESCRIPTION
commit 6942c57632613de7a19ed38447e7da10a5675f52 (HEAD -> PHPMockingUtilities1682093085, origin/PHPMockingUtilities1682093085)
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Tue Apr 25 17:22:13 2023 -0400

    Implemented the following new assertion in
    `tests/interfaces/mock/values/MockClassInstanceTestTrait.php`:

    ```
    assertRuntimeExceptionIsThrownIfAnyOfTheParametersDefinedByTheSpecifiedMethodExpectAnImplementationOfAnInterfaceOrAnAbstractClass()

    ```

    This assertion expects a RuntimeException to be thrown by implementations
    of the `Darling\PHPMockingUtilities\interfaces\mock\values\MockClassInstance->mockMethodArguments()`
    method if any of the parameters defined by the specified method expect
    an instance of an implementation of an interface or abstract class.

    The 2 exceptions to this expectation:

    - Parameters that expect an interface or abstract class defined
      by a Darling library that is not defined under a testing namespace
      can be mocked.

    - Parameters that expect an implementation of the `Stringable`
      can be mocked because an UnknownClass is an implementation of
      the Stringable interface.

commit 6e73c6200479be16c683ae36c5858b18dd9a4081
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Tue Apr 25 12:28:24 2023 -0400

    Cleaned up code, revised documentation.

    Resolved issues that were causing the following test to fail:

    ```
    test_mock_method_arguments_returns_an_array_of_mock_arguments_of_the_correct_type_for_the_specified_method_of_the_class_or_object_instance_reflected_by_the_reflection_returned_by_the_mock_class_instances_reflection_method

    ```

    It is not possible to mock arguments for a method that expects
    an implementation of a interface or abstract class since it
    is not possible to instantiate a interface or abstract class.

    The test now expects a `RuntimeException` to be thrown if
    `MockClassInstance->mockMethodArguments` is called to mock
    method arguments for a method that defines one or more
    parameters that expect an implementation of an interface
    or an abstract class.

commit 3b54ed4f6b99f171fcc2b476682584b635a915c7
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Tue Apr 25 08:32:23 2023 -0400

    Renamed test methods using snake case instead of camel case in:

    ```
    tests/interfaces/mock/values/MockClassInstanceTestTrait.php

    ```

commit 1a1e0977f25af453b13425487bbf336ac26a55f7
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Sat Apr 22 03:00:31 2023 -0400

    Working on addressing issue #10

    Code clean up.

    Restored original tess.

commit c8c898c99b65196b81f949a9a4b05fb2547925c3
Author: sevidmusic <sevidmusic@gmail.com>
Date:   Fri Apr 21 14:14:09 2023 -0400

    Working on addressing issue #10.

    Implemented the following test in the
    `Darling\PHPMockingUtilities\tests\interfaces\mock\values\MockClassInstanceTestTrait`:

    ```
    testMockInstanceReturnsAnInstanceOfTheSameTypeAsTheClassOrObjectInstanceReflectedByTheReflectionAssignedToTheMockClassInstance()

    ```

    All tests defined for
    `Darling\PHPMockingUtilities\classes\mock\values\MockClassInstance`
    by the
    `Darling\PHPMockingUtilities\tests\interfaces\mock\values\MockClassInstanceTestTrait`
    are passing.