### PR TITLE
issue #36 is in fact resolved

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,24 +8,23 @@
     "packages": [
         {
             "name": "darling/php-darling-dev-tools",
-            "version": "v1.0.4",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sevidmusic/PHPDarlingDevTools.git",
-                "reference": "85d112f35eccd23ae45a264f2849778e4dba53fc"
+                "reference": "5fda9084c7931328f4a7a8599693f647d8b3d06b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sevidmusic/PHPDarlingDevTools/zipball/85d112f35eccd23ae45a264f2849778e4dba53fc",
-                "reference": "85d112f35eccd23ae45a264f2849778e4dba53fc",
+                "url": "https://api.github.com/repos/sevidmusic/PHPDarlingDevTools/zipball/5fda9084c7931328f4a7a8599693f647d8b3d06b",
+                "reference": "5fda9084c7931328f4a7a8599693f647d8b3d06b",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.1"
             },
             "require-dev": {
-                "phpstan/phpstan": "*",
-                "phpunit/phpunit": "*"
+                "phpstan/phpstan": "*"
             },
             "type": "library",
             "autoload": {
@@ -47,9 +46,9 @@
             "description": "Development tools for development of Darling PHP libraries and projects. ",
             "support": {
                 "issues": "https://github.com/sevidmusic/PHPDarlingDevTools/issues",
-                "source": "https://github.com/sevidmusic/PHPDarlingDevTools/tree/v1.0.4"
+                "source": "https://github.com/sevidmusic/PHPDarlingDevTools/tree/v1.0.6"
             },
-            "time": "2023-06-01T06:50:19+00:00"
+            "time": "2023-07-06T23:07:13+00:00"
         },
         {
             "name": "darling/php-reflection-utilities",
@@ -252,16 +251,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.5",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
-                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -302,9 +301,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-05-19T20:20:00+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -419,16 +418,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.18",
+            "version": "1.10.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "52b6416c579663eebdd2f1d97df21971daf3b43f"
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52b6416c579663eebdd2f1d97df21971daf3b43f",
-                "reference": "52b6416c579663eebdd2f1d97df21971daf3b43f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578f4e70d117f9a90699324c555922800ac38d8c",
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c",
                 "shasum": ""
             },
             "require": {
@@ -477,7 +476,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-07T22:00:43+00:00"
+            "time": "2023-07-06T12:11:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -801,16 +800,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.1",
+            "version": "10.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "599b33294350e8f51163119d5670512f98b0490d"
+                "reference": "35c8cac1734ede2ae354a6644f7088356ff5b08e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/599b33294350e8f51163119d5670512f98b0490d",
-                "reference": "599b33294350e8f51163119d5670512f98b0490d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/35c8cac1734ede2ae354a6644f7088356ff5b08e",
+                "reference": "35c8cac1734ede2ae354a6644f7088356ff5b08e",
                 "shasum": ""
             },
             "require": {
@@ -882,7 +881,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.1"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.3"
             },
             "funding": [
                 {
@@ -898,7 +897,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-05T05:15:51+00:00"
+            "time": "2023-06-30T06:17:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/tests/integration/TestMockClassInstanceCanMockReflectionClassesProvidedByPHPsStandardLibrary.php
+++ b/tests/integration/TestMockClassInstanceCanMockReflectionClassesProvidedByPHPsStandardLibrary.php
@@ -70,9 +70,9 @@ function instanceOfAStandardLibraryReflectionType(): mixed
         new ReflectionProperty(Text::class, 'string'),
         new ReflectionUnionType(),
         $reflectionReference,
-        new ReflectionEnum(FooBarBaz::class), # Fails
-        new ReflectionEnumBackedCase(FooBarBazBacked::class, 'Bar'), # Fails
-        new ReflectionEnumUnitCase(FooBarBaz::class, 'Foo'), # Fails
+        new ReflectionEnum(FooBarBaz::class),
+        new ReflectionEnumBackedCase(FooBarBazBacked::class, 'Bar'),
+        new ReflectionEnumUnitCase(FooBarBaz::class, 'Foo'),
 #        // NOT TESTED YET
 #        new ReflectionZendExtension(''),
 #        new ReflectionAttribute(),
@@ -80,13 +80,16 @@ function instanceOfAStandardLibraryReflectionType(): mixed
     return $classes[array_rand($classes)];
 }
 
+$instance = instanceOfAStandardLibraryReflectionType();
 $mi = new MockClassInstance(
-    new DarlingReflection(
-        new ClassString(
-            instanceOfAStandardLibraryReflectionType()
-        )
-    )
+    new DarlingReflection(new ClassString($instance))
 );
 
-var_dump($mi->mockInstance());
+echo "\033[38;5;0m\033[48;5;111mRunning test" . __FILE__ . " \033[48;5;0m";
+
+if($mi->mockInstance()::class === $instance::class) {
+    echo "\033[38;5;0m\033[48;5;84mPassed\033[48;5;0m";
+} else {
+    echo "\033[38;5;0m\033[48;5;196mFailed\033[48;5;0m";
+}
 


### PR DESCRIPTION
Began looking deeper into issue #36, it was re-opened because itseemed like the issue might still be present, after running the integration tests with the problematic object instances re-enabled the tests passed.

Relevant test:

```
tests/integration/TestMockClassInstanceCanMockReflectionClassesProvidedByPHPsStandardLibrary.php

```

The error the caused this issue to be re-opened may have actually been a result of an issue with the PHPJsonUtilities library since at the time there were a few issues with the PHPJsonUtilities library that had not yet  been addressed.

It is possible to mock the various types of Reflection classes provided by php's standard library that are tested in:

```
tests/integration/TestMockClassInstanceCanMockReflectionClassesProvidedByPHPsStandardLibrary.php

```